### PR TITLE
Patcher

### DIFF
--- a/levels/wf/script.c
+++ b/levels/wf/script.c
@@ -40,7 +40,7 @@ static const LevelScript script_func_local_2[] = {
     OBJECT(/*model*/ MODEL_WF_SLIDING_PLATFORM,         /*pos*/  3328, 1075,  -767, /*angle*/ 0,  90, 0, /*behParam*/ 0x00010000, /*beh*/ bhvWfSlidingPlatform),
     OBJECT(/*model*/ MODEL_WF_SLIDING_PLATFORM,         /*pos*/  3328, 1075, -2815, /*angle*/ 0,  90, 0, /*behParam*/ 0x00030000, /*beh*/ bhvWfSlidingPlatform),
     OBJECT(/*model*/ MODEL_WF_TUMBLING_BRIDGE,          /*pos*/  1792, 2496,  1600, /*angle*/ 0,   0, 0, /*behParam*/ 0x00000000, /*beh*/ bhvWfTumblingBridge),
-    OBJECT(/*model*/ MODEL_WF_BREAKABLE_WALL_RIGHT,     /*pos*/   512, 2176,  2944, /*angle*/ 0,   0, 0, /*behParam*/ 0x00000000, /*beh*/ bhvWfBreakableWallRight),
+    OBJECT(/*model*/ MODEL_WF_BREAKABLE_WALL_RIGHT,     /*pos*/   512, 2176,  2944, /*angle*/ 0,   0, 0, /*behParam*/ 0x05000000, /*beh*/ bhvWfBreakableWallRight),
     OBJECT(/*model*/ MODEL_WF_BREAKABLE_WALL_LEFT,      /*pos*/ -1023, 2176,  2944, /*angle*/ 0,   0, 0, /*behParam*/ 0x00000000, /*beh*/ bhvWfBreakableWallLeft),
     OBJECT_WITH_ACTS(/*model*/ MODEL_WF_KICKABLE_BOARD,           /*pos*/    13, 3584, -1407, /*angle*/ 0, 315, 0, /*behParam*/ 0x00000000, /*beh*/ bhvKickableBoard, /*acts*/ ACT_2 | ACT_3 | ACT_4 | ACT_5 | ACT_6),
     OBJECT_WITH_ACTS(/*model*/ MODEL_1UP,                         /*pos*/  -384, 3584,     6, /*angle*/ 0,   0, 0, /*behParam*/ 0x00000000, /*beh*/ bhv1Up,            /*acts*/ ACT_2 | ACT_3 | ACT_4 | ACT_5 | ACT_6),
@@ -87,7 +87,6 @@ static const LevelScript script_func_local_4[] = {
     OBJECT_WITH_ACTS(/*model*/ MODEL_STAR,  /*pos*/ -2500, 1500, -750, /*angle*/ 0, 0, 0, /*behParam*/ 0x02000000, /*beh*/ bhvStar,                 /*acts*/ ALL_ACTS),
     OBJECT_WITH_ACTS(/*model*/ MODEL_NONE,  /*pos*/  4600,  550, 2500, /*angle*/ 0, 0, 0, /*behParam*/ 0x03000000, /*beh*/ bhvHiddenRedCoinStar, /*acts*/ ALL_ACTS),
     OBJECT_WITH_ACTS(/*model*/ MODEL_STAR,  /*pos*/  2880, 4300,  190, /*angle*/ 0, 0, 0, /*behParam*/ 0x04000000, /*beh*/ bhvStar,                 /*acts*/ ALL_ACTS),
-    OBJECT_WITH_ACTS(/*model*/ MODEL_STAR,  /*pos*/   590, 2450, 2650, /*angle*/ 0, 0, 0, /*behParam*/ 0x05000000, /*beh*/ bhvStar,                 /*acts*/ ALL_ACTS),
     RETURN(),
 };
 

--- a/src/game/behaviors/breakable_wall.inc.c
+++ b/src/game/behaviors/breakable_wall.inc.c
@@ -5,6 +5,7 @@ void bhv_wf_breakable_wall_loop(void) {
         cur_obj_become_tangible();
         if (obj_check_if_collided_with_object(o, gMarioObject)) {
             if (cur_obj_has_behavior(bhvWfBreakableWallRight))
+				spawn_default_star(590.0f, 2450.0f, 2650.0f);
                 play_puzzle_jingle();
             create_sound_spawner(SOUND_GENERAL_WALL_EXPLOSION);
             o->oInteractType = 8;

--- a/src/game/behaviors/camera_lakitu.inc.c
+++ b/src/game/behaviors/camera_lakitu.inc.c
@@ -27,8 +27,9 @@ void bhv_camera_lakitu_init(void) {
  */
 static void camera_lakitu_intro_act_trigger_cutscene(void) {
     //! These bounds are slightly smaller than the actual bridge bounds, allowing
+	// not anymore :)
     //  the RTA speedrunning method of lakitu skip
-    if (gMarioObject->oPosX > -544.0f && gMarioObject->oPosX < 545.0f && gMarioObject->oPosY > 800.0f
+    if (gMarioObject->oPosX > -555.0f && gMarioObject->oPosX < 555.0f && gMarioObject->oPosY > 800.0f
         && gMarioObject->oPosZ > -2000.0f && gMarioObject->oPosZ < -177.0f
         && gMarioObject->oPosZ < -177.0f) // always double check your conditions
     {

--- a/src/game/interaction.c
+++ b/src/game/interaction.c
@@ -1050,7 +1050,7 @@ u32 interact_door(struct MarioState *m, UNUSED u32 interactType, struct Object *
 }
 
 u32 interact_cannon_base(struct MarioState *m, UNUSED u32 interactType, struct Object *o) {
-    if (m->action != ACT_IN_CANNON) {
+    if (m->action != ACT_IN_CANNON && m->health >= 0x100) {
         mario_stop_riding_and_holding(m);
         o->oInteractStatus = INT_STATUS_INTERACTED;
         m->interactObj = o;

--- a/src/game/mario.c
+++ b/src/game/mario.c
@@ -253,6 +253,7 @@ void play_sound_if_no_flag(struct MarioState *m, u32 soundBits, u32 flags) {
 /**
  * Plays a jump sound if one has not been played since the last action change.
  */
+ 
 void play_mario_jump_sound(struct MarioState *m) {
     if (!(m->flags & MARIO_MARIO_SOUND_PLAYED)) {
 #ifndef VERSION_JP
@@ -875,11 +876,18 @@ static u32 set_mario_action_airborne(struct MarioState *m, u32 action, u32 actio
             set_mario_y_vel_based_on_fspeed(m, 30.0f, 0.0f);
             m->marioObj->oMarioLongJumpIsSlow = m->forwardVel > 16.0f ? FALSE : TRUE;
 
-            //! (BLJ's) This properly handles long jumps from getting forward speed with
-            //  too much velocity, but misses backwards longs allowing high negative speeds.
+            //  This properly handles long jumps from getting forward speed with
+            //  too much velocity.
             if ((m->forwardVel *= 1.5f) > 48.0f) {
                 m->forwardVel = 48.0f;
             }
+			
+			//! BLJ fix
+			if (m->forwardVel < -25.0f) {
+                m->forwardVel = -25.0f;
+            }
+			//! end of the BLJ fix
+			
             break;
 
         case ACT_SLIDE_KICK:
@@ -1060,7 +1068,8 @@ s32 set_jump_from_landing(struct MarioState *m) {
                         set_mario_action(m, ACT_FLYING_TRIPLE_JUMP, 0);
                     } else if (m->forwardVel > 20.0f) {
                         set_mario_action(m, ACT_TRIPLE_JUMP, 0);
-                    } else {
+					}
+					else {
                         set_mario_action(m, ACT_JUMP, 0);
                     }
                     break;
@@ -1532,7 +1541,8 @@ void update_mario_health(struct MarioState *m) {
         }
 
         // Play a noise to alert the player when Mario is close to drowning.
-        if (((m->action & ACT_GROUP_MASK) == ACT_GROUP_SUBMERGED) && (m->health < 0x300)) {
+        if (((m->action & ACT_GROUP_MASK) == ACT_GROUP_SUBMERGED) && (m->health < 0x300) && !((m->flags & (MARIO_METAL_CAP))
+                > 0)) {
             play_sound(SOUND_MOVING_ALMOST_DROWNING, gDefaultSoundArgs);
             if (!gRumblePakTimer) {
                 gRumblePakTimer = 36;

--- a/src/game/mario_actions_moving.c
+++ b/src/game/mario_actions_moving.c
@@ -151,7 +151,8 @@ void slide_bonk(struct MarioState *m, u32 fastAction, u32 slowAction) {
 s32 set_triple_jump_action(struct MarioState *m, UNUSED u32 action, UNUSED u32 actionArg) {
     if (m->flags & MARIO_WING_CAP) {
         return set_mario_action(m, ACT_FLYING_TRIPLE_JUMP, 0);
-    } else if (m->forwardVel > 20.0f) {
+    } else if (m->forwardVel > 20.0f && ((mario_get_floor_class(m) == SURFACE_CLASS_NOT_SLIPPERY) || (mario_get_floor_class(m) == SURFACE_CLASS_DEFAULT)
+		|| (mario_get_floor_class(m) == SURFACE_HARD_NOT_SLIPPERY) && SURFACE_HARD_SLIPPERY) {
         return set_mario_action(m, ACT_TRIPLE_JUMP, 0);
     } else {
         return set_mario_action(m, ACT_JUMP, 0);
@@ -857,7 +858,13 @@ s32 act_move_punching(struct MarioState *m) {
     }
 
     if (m->actionState == 0 && (m->input & INPUT_A_DOWN)) {
-        return set_mario_action(m, ACT_JUMP_KICK, 0);
+		if ((mario_get_floor_class(m) == SURFACE_CLASS_NOT_SLIPPERY) || (mario_get_floor_class(m) == SURFACE_CLASS_DEFAULT)
+		|| (mario_get_floor_class(m) == SURFACE_HARD_NOT_SLIPPERY) && SURFACE_HARD_SLIPPERY) {
+			return set_mario_action(m, ACT_JUMP_KICK, 0);
+		}
+		else {
+			return set_mario_action(m, ACT_DIVE, 0);
+		}
     }
 
     m->actionState = 1;


### PR DESCRIPTION
- Patched the Backwards Long Jump
- The drowning noise when Mario is close to drowning no longer plays when Mario has the metal cap
- You can now get 1ups every 50 coins when finishing a course (was capped as 150 as the developers never thought anyone would get to 200+)
- Patched "Blast away the wall" skip
- Patched the Lakitu Skip
- Patched triple jumping & Kicking on slopes
- Patched the Hands-free holding when bonking
- Patched the "Zombie Mario" Glitch using a cannon